### PR TITLE
Missing counterparts of obsoleted methods

### DIFF
--- a/Source/AsyncGenerator.Tests/MissingMembers/Fixture.cs
+++ b/Source/AsyncGenerator.Tests/MissingMembers/Fixture.cs
@@ -105,5 +105,28 @@ namespace AsyncGenerator.Tests.MissingMembers
 				)
 			);
 		}
+
+		[Test]
+		public Task TestAbstractBaseAfterTransformation()
+		{
+			return ReadonlyTest(nameof(AbstractBase), o => o
+				.ConfigureParsing(p => p
+					.AddPreprocessorSymbolName("TEST")
+				)
+				.ConfigureAnalyzation(a => a
+					.ScanForMissingAsyncMembers(true)
+				)
+				.ConfigureTransformation(t => t
+					.AfterTransformation(result =>
+					{
+						AssertValidAnnotations(result);
+						Assert.AreEqual(1, result.Documents.Count);
+						var document = result.Documents[0];
+						Assert.NotNull(document.OriginalModified);
+						Assert.AreEqual(GetOutputFile(nameof(AbstractBase)), document.Transformed.ToFullString());
+					})
+				)
+			);
+		}
 	}
 }

--- a/Source/AsyncGenerator.Tests/MissingMembers/Input/AbstractBase.cs
+++ b/Source/AsyncGenerator.Tests/MissingMembers/Input/AbstractBase.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using AsyncGenerator.TestCases;
+
+namespace AsyncGenerator.Tests.MissingMembers.Input
+{
+#if TEST
+	public abstract partial class AbstractBase
+	{
+		public abstract Task MethodAsync();
+
+		protected abstract Task<bool> Method2Async(CancellationToken cancellationToken);
+
+		internal abstract Task<bool> Method3Async(CancellationToken cancellationToken = default(CancellationToken));
+
+		[Obsolete]
+		public abstract Task<bool> Method4Async(CancellationToken cancellationToken = default(CancellationToken));
+
+		[Obsolete("Obsolete attribute should be copied to concrete implementation")]
+		public abstract Task<bool> Method5Async(CancellationToken cancellationToken = default(CancellationToken));
+
+		[Obsolete("Obsolete async base")]
+		public abstract Task<bool> Method6Async(CancellationToken cancellationToken = default(CancellationToken));
+	}
+#endif
+
+	public abstract partial class AbstractBase
+	{
+		public abstract void Method();
+
+		protected abstract bool Method2();
+
+		internal abstract bool Method3();
+
+		public abstract bool Method4();
+
+		public abstract bool Method5();
+
+		[Obsolete("Obsolete sync base")]
+		public abstract bool Method6();
+	}
+
+	public class TestAbstract : AbstractBase
+	{
+		public override void Method()
+		{
+		}
+
+		protected override bool Method2()
+		{
+			return true;
+		}
+
+		internal override bool Method3()
+		{
+			return true;
+		}
+
+		public override bool Method4()
+		{
+			return true;
+		}
+
+		public override bool Method5()
+		{
+			return true;
+		}
+
+		[Obsolete("Obsolete sync")]
+		public override bool Method6()
+		{
+			return true;
+		}
+	}
+}

--- a/Source/AsyncGenerator.Tests/MissingMembers/Input/GetterProperty.cs
+++ b/Source/AsyncGenerator.Tests/MissingMembers/Input/GetterProperty.cs
@@ -16,6 +16,15 @@ namespace AsyncGenerator.Tests.MissingMembers.Input
 		Task<bool> GetWriteSuccess2Async();
 
 		Task<bool> GetWriteSuccess3Async();
+
+		[Obsolete]
+		Task<bool> GetWriteSuccess4Async();
+
+		[Obsolete("Obsolete attribute should be copied to concrete implementation")]
+		Task<bool> GetWriteSuccess5Async();
+
+		[Obsolete("Obsolete async interface")]
+		Task<bool> GetWriteSuccess6Async();
 	}
 #endif
 
@@ -24,6 +33,13 @@ namespace AsyncGenerator.Tests.MissingMembers.Input
 		bool WriteSuccess { get; }
 
 		bool WriteSuccess2 { get; }
+
+		bool WriteSuccess4 { get; }
+
+		bool WriteSuccess5 { get; }
+
+		[Obsolete("Obsolete sync interface")]
+		bool WriteSuccess6 { get; }
 	}
 
 	public class GetterProperty : IGetterProperty
@@ -33,5 +49,12 @@ namespace AsyncGenerator.Tests.MissingMembers.Input
 		public bool WriteSuccess2 => SimpleFile.Write("2");
 
 		public bool WriteSuccess3 { get => SimpleFile.Write("3"); }
+
+		public bool WriteSuccess4 => true;
+
+		public bool WriteSuccess5 => false;
+
+		[Obsolete("Obsolete sync")]
+		public bool WriteSuccess6 => true;
 	}
 }

--- a/Source/AsyncGenerator.Tests/MissingMembers/Input/TestCase.cs
+++ b/Source/AsyncGenerator.Tests/MissingMembers/Input/TestCase.cs
@@ -16,6 +16,15 @@ namespace AsyncGenerator.Tests.MissingMembers.Input
 		Task<bool> Method2Async(CancellationToken cancellationToken);
 
 		Task<bool> Method3Async(CancellationToken cancellationToken = default(CancellationToken));
+
+		[Obsolete]
+		Task<bool> Method4Async(CancellationToken cancellationToken = default(CancellationToken));
+
+		[Obsolete("Obsolete attribute should be copied to concrete implementation")]
+		Task<bool> Method5Async(CancellationToken cancellationToken = default(CancellationToken));
+
+		[Obsolete("Obsolete async interface")]
+		Task<bool> Method6Async(CancellationToken cancellationToken = default(CancellationToken));
 	}
 #endif
 
@@ -26,6 +35,13 @@ namespace AsyncGenerator.Tests.MissingMembers.Input
 		bool Method2();
 
 		bool Method3();
+
+		bool Method4();
+
+		bool Method5();
+
+		[Obsolete("Obsolete sync interface")]
+		bool Method6();
 	}
 
 	public class TestCase : IInterface
@@ -40,6 +56,22 @@ namespace AsyncGenerator.Tests.MissingMembers.Input
 		}
 
 		public bool Method3()
+		{
+			return true;
+		}
+
+		public bool Method4()
+		{
+			return true;
+		}
+
+		public bool Method5()
+		{
+			return true;
+		}
+
+		[Obsolete("Obsolete sync")]
+		public bool Method6()
 		{
 			return true;
 		}

--- a/Source/AsyncGenerator.Tests/MissingMembers/Output/AbstractBase.txt
+++ b/Source/AsyncGenerator.Tests/MissingMembers/Output/AbstractBase.txt
@@ -23,37 +23,37 @@ namespace AsyncGenerator.Tests.MissingMembers.Input
 
 	#endif
 
-	public partial class TestCase : IInterface
+	public partial class TestAbstract : AbstractBase
 	{
-		public Task MethodAsync()
+		public override Task MethodAsync()
 		{
 			return Task.CompletedTask;
 		}
 
-		public Task<bool> Method2Async(CancellationToken cancellationToken)
+		protected override Task<bool> Method2Async(CancellationToken cancellationToken)
 		{
 			return Task.FromResult<bool>(true);
 		}
 
-		public Task<bool> Method3Async(CancellationToken cancellationToken = default(CancellationToken))
+		internal override Task<bool> Method3Async(CancellationToken cancellationToken = default(CancellationToken))
 		{
 			return Task.FromResult<bool>(true);
 		}
 
 		[Obsolete]
-		public Task<bool> Method4Async(CancellationToken cancellationToken = default(CancellationToken))
+		public override Task<bool> Method4Async(CancellationToken cancellationToken = default(CancellationToken))
 		{
 			return Task.FromResult<bool>(true);
 		}
 
 		[Obsolete("Obsolete attribute should be copied to concrete implementation")]
-		public Task<bool> Method5Async(CancellationToken cancellationToken = default(CancellationToken))
+		public override Task<bool> Method5Async(CancellationToken cancellationToken = default(CancellationToken))
 		{
 			return Task.FromResult<bool>(true);
 		}
 
 		[Obsolete("Obsolete sync")]
-		public Task<bool> Method6Async(CancellationToken cancellationToken = default(CancellationToken))
+		public override Task<bool> Method6Async(CancellationToken cancellationToken = default(CancellationToken))
 		{
 			return Task.FromResult<bool>(true);
 		}

--- a/Source/AsyncGenerator.Tests/MissingMembers/Output/GetterProperty.txt
+++ b/Source/AsyncGenerator.Tests/MissingMembers/Output/GetterProperty.txt
@@ -32,5 +32,14 @@ namespace AsyncGenerator.Tests.MissingMembers.Input
 		public Task<bool> GetWriteSuccess2Async() => SimpleFile.WriteAsync("2");
 
 		public Task<bool> GetWriteSuccess3Async() => SimpleFile.WriteAsync("3");
+
+		[Obsolete]
+		public Task<bool> GetWriteSuccess4Async() => Task.FromResult<bool>(true);
+
+		[Obsolete("Obsolete attribute should be copied to concrete implementation")]
+		public Task<bool> GetWriteSuccess5Async() => Task.FromResult<bool>(false);
+
+		[Obsolete("Obsolete sync")]
+		public Task<bool> GetWriteSuccess6Async() => Task.FromResult<bool>(true);
 	}
 }

--- a/Source/AsyncGenerator/Analyzation/Internal/ProjectAnalyzer.PreAnalyze.cs
+++ b/Source/AsyncGenerator/Analyzation/Internal/ProjectAnalyzer.PreAnalyze.cs
@@ -409,15 +409,21 @@ namespace AsyncGenerator.Analyzation.Internal
 					methodData.SoftCopy();
 				}
 
+				var relatedAsyncMember = methodData.RelatedAsyncMethods
+					.First(o => o.IsVirtual || o.IsAbstract);
+				// Copy the obsolete attribute if any exists on the related method while the method itself does not have one
+				var relatedObsolete = relatedAsyncMember.GetAttributes().FirstOrDefault(a => a.AttributeClass.Name == nameof(ObsoleteAttribute));
+				if (relatedObsolete != null && !methodData.Symbol.GetAttributes().Any(a => a.AttributeClass.Name == nameof(ObsoleteAttribute)))
+				{
+					//methodData.
+				}
+
 				// We have to generate the cancellation token parameter if the async member has more parameters that the sync counterpart
-				var asyncMember = methodData.RelatedAsyncMethods
-					.Where(o => o.IsVirtual || o.IsAbstract)
-					.FirstOrDefault(o => o.Parameters.Length > methodData.Symbol.Parameters.Length);
-				if (asyncMember != null)
+				if (relatedAsyncMember.Parameters.Length > methodData.Symbol.Parameters.Length)
 				{
 					methodData.CancellationTokenRequired = true;
 					// We suppose that the cancellation token is the last parameter
-					methodData.MethodCancellationToken = asyncMember.Parameters.Last().HasExplicitDefaultValue
+					methodData.MethodCancellationToken = relatedAsyncMember.Parameters.Last().HasExplicitDefaultValue
 						? MethodCancellationToken.Optional
 						: MethodCancellationToken.Required;
 				}


### PR DESCRIPTION
Tests for #102, Obsolete async method in base class should also be generated obsolete in overrides 