### PR TITLE
Add support for dotnet tool

### DIFF
--- a/Source/AsyncGenerator.CommandLine/AsyncGenerator.CommandLine.csproj
+++ b/Source/AsyncGenerator.CommandLine/AsyncGenerator.CommandLine.csproj
@@ -4,6 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFrameworks>$(AppTargetFrameworks)</TargetFrameworks>
     <ServerGarbageCollection>true</ServerGarbageCollection>
+    <PackageType>DotnetTool</PackageType>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -12,13 +13,21 @@
     <PackageId>CSharpAsyncGenerator.CommandLine</PackageId>
     <Product>AsyncGenerator.CommandLine</Product>
     <Description>Tool for generating async C# code</Description>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>async-generator</ToolCommandName>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)' != 'netcoreapp2.1'">
     <IsTool>true</IsTool>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
-    
-  <ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp2.1'">
     <Content Include="$(OutputPath)\**\*.dll;$(OutputPath)\**\*.exe;$(OutputPath)\**\*runtimeconfig.json;$(OutputPath)\**\AsyncGenerator.CommandLine*.config;">
       <Pack>true</Pack>
       <PackagePath>tools</PackagePath>
@@ -35,25 +44,26 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
+    <PackageReference Include="log4net" Version="2.0.8" />
+    <PackageReference Include="Microsoft.Build.Locator" Version="1.2.6" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.0.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="3.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp2.1'">
     <PackageReference Include="log4net" Version="2.0.8">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Build.Locator" Version="1.2.6">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.0.0">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="3.0.0">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp2.1'">
     <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.6.0">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
@@ -61,17 +71,11 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
-
+  
   <ItemGroup>
-    <ProjectReference Include="..\AsyncGenerator.Configuration.Yaml\AsyncGenerator.Configuration.Yaml.csproj">
-      <PrivateAssets>all</PrivateAssets>
-    </ProjectReference>
-    <ProjectReference Include="..\AsyncGenerator.Core\AsyncGenerator.Core.csproj">
-      <PrivateAssets>all</PrivateAssets>
-    </ProjectReference>
-    <ProjectReference Include="..\AsyncGenerator\AsyncGenerator.csproj">
-      <PrivateAssets>all</PrivateAssets>
-    </ProjectReference>
+    <ProjectReference Include="..\AsyncGenerator.Configuration.Yaml\AsyncGenerator.Configuration.Yaml.csproj" />
+    <ProjectReference Include="..\AsyncGenerator.Core\AsyncGenerator.Core.csproj" />
+    <ProjectReference Include="..\AsyncGenerator\AsyncGenerator.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Breaking change: `netcoreapp2.1` files are moved to `tools/netcoreapp2.1/any` folder which is caused by adding `<PackAsTool>true</PackAsTool>`.