### PR TITLE
Publish dotnet tool as a separate package

### DIFF
--- a/Common.props
+++ b/Common.props
@@ -14,5 +14,6 @@
     <LibTargetFrameworks Condition ="$(LibTargetFrameworks) == ''">netstandard2.0</LibTargetFrameworks>
     <AppTargetFrameworks Condition ="$(AppTargetFrameworks) == ''">net472;netcoreapp2.1</AppTargetFrameworks>
     <TestTargetFramework Condition ="$(TestTargetFramework) == ''">net472</TestTargetFramework>
+    <ToolTargetFramework Condition ="$(ToolTargetFramework) == ''">netcoreapp2.1</ToolTargetFramework>
   </PropertyGroup>
 </Project>

--- a/Source/AsyncGenerator.CommandLine/AsyncGenerator.CommandLine.csproj
+++ b/Source/AsyncGenerator.CommandLine/AsyncGenerator.CommandLine.csproj
@@ -4,7 +4,6 @@
     <OutputType>Exe</OutputType>
     <TargetFrameworks>$(AppTargetFrameworks)</TargetFrameworks>
     <ServerGarbageCollection>true</ServerGarbageCollection>
-    <PackageType>DotnetTool</PackageType>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -13,21 +12,13 @@
     <PackageId>CSharpAsyncGenerator.CommandLine</PackageId>
     <Product>AsyncGenerator.CommandLine</Product>
     <Description>Tool for generating async C# code</Description>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
-    <PackAsTool>true</PackAsTool>
-    <ToolCommandName>async-generator</ToolCommandName>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(TargetFramework)' != 'netcoreapp2.1'">
     <IsTool>true</IsTool>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp2.1'">
+  <ItemGroup>
     <Content Include="$(OutputPath)\**\*.dll;$(OutputPath)\**\*.exe;$(OutputPath)\**\*runtimeconfig.json;$(OutputPath)\**\AsyncGenerator.CommandLine*.config;">
       <Pack>true</Pack>
       <PackagePath>tools</PackagePath>

--- a/Source/AsyncGenerator.Tool/AsyncGenerator.Tool.csproj
+++ b/Source/AsyncGenerator.Tool/AsyncGenerator.Tool.csproj
@@ -4,17 +4,17 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>$(ToolTargetFramework)</TargetFramework>
     <ServerGarbageCollection>true</ServerGarbageCollection>
+    <Product>AsyncGenerator.Tool</Product>
+    <Description>dotnet tool for generating async C# code</Description>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
+    <PackageId>CSharpAsyncGenerator.Tool</PackageId>
     <PackageType>DotnetTool</PackageType>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>async-generator</ToolCommandName>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
-    <PackageId>CSharpAsyncGenerator.Tool</PackageId>
-    <Product>AsyncGenerator.Tool</Product>
-    <Description>dotnet tool for generating async C# code</Description>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/Source/AsyncGenerator.Tool/AsyncGenerator.Tool.csproj
+++ b/Source/AsyncGenerator.Tool/AsyncGenerator.Tool.csproj
@@ -1,0 +1,61 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="..\..\Common.props" />
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>$(ToolTargetFramework)</TargetFramework>
+    <ServerGarbageCollection>true</ServerGarbageCollection>
+    <PackageType>DotnetTool</PackageType>
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>async-generator</ToolCommandName>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+    <PackageId>CSharpAsyncGenerator.Tool</PackageId>
+    <Product>AsyncGenerator.Tool</Product>
+    <Description>dotnet tool for generating async C# code</Description>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <DefineConstants>TRACE;ENV</DefineConstants>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <DefineConstants>TRACE;DEBUG;ENV</DefineConstants>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="log4net" Version="2.0.8" />
+    <PackageReference Include="Microsoft.Build.Locator" Version="1.2.6" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.0.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="3.0.0" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <ProjectReference Include="..\AsyncGenerator.Configuration.Yaml\AsyncGenerator.Configuration.Yaml.csproj" />
+    <ProjectReference Include="..\AsyncGenerator.Core\AsyncGenerator.Core.csproj" />
+    <ProjectReference Include="..\AsyncGenerator\AsyncGenerator.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\AsyncGenerator\Internal\EnvironmentHelper.cs">
+      <Link>EnvironmentHelper.cs</Link>
+    </Compile>
+    <Compile Include="..\AsyncGenerator.CommandLine\Log4NetLogger.cs">
+      <Link>Log4NetLogger.cs</Link>
+    </Compile>
+    <Compile Include="..\AsyncGenerator.CommandLine\Log4NetLoggerFactory.cs">
+      <Link>Log4NetLoggerFactory.cs</Link>
+    </Compile>
+    <Compile Include="..\AsyncGenerator.CommandLine\Program.cs">
+      <Link>Program.cs</Link>
+    </Compile>
+    <None Include="..\AsyncGenerator.CommandLine\App.config">
+      <Link>App.config</Link>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/Source/AsyncGenerator.sln
+++ b/Source/AsyncGenerator.sln
@@ -1,19 +1,21 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26430.13
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29613.14
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AsyncGenerator", "AsyncGenerator/AsyncGenerator.csproj", "{9D321EA8-54AE-4741-86A8-12198551AD67}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AsyncGenerator", "AsyncGenerator\AsyncGenerator.csproj", "{9D321EA8-54AE-4741-86A8-12198551AD67}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AsyncGenerator.Tests", "AsyncGenerator.Tests/AsyncGenerator.Tests.csproj", "{0A3D852A-5C81-4E74-AC16-85BA2EBF3581}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AsyncGenerator.Tests", "AsyncGenerator.Tests\AsyncGenerator.Tests.csproj", "{0A3D852A-5C81-4E74-AC16-85BA2EBF3581}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AsyncGenerator.TestCases", "AsyncGenerator.TestCases/AsyncGenerator.TestCases.csproj", "{A183D706-0DBB-4F6B-92A5-6359660255D7}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AsyncGenerator.TestCases", "AsyncGenerator.TestCases\AsyncGenerator.TestCases.csproj", "{A183D706-0DBB-4F6B-92A5-6359660255D7}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AsyncGenerator.Core", "AsyncGenerator.Core/AsyncGenerator.Core.csproj", "{7F45BDB9-6B8D-421F-9F91-D92AAB8F0F24}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AsyncGenerator.Core", "AsyncGenerator.Core\AsyncGenerator.Core.csproj", "{7F45BDB9-6B8D-421F-9F91-D92AAB8F0F24}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AsyncGenerator.Configuration.Yaml", "AsyncGenerator.Configuration.Yaml/AsyncGenerator.Configuration.Yaml.csproj", "{C130CF5A-6543-4396-99C3-E223FF3C5EEE}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AsyncGenerator.Configuration.Yaml", "AsyncGenerator.Configuration.Yaml\AsyncGenerator.Configuration.Yaml.csproj", "{C130CF5A-6543-4396-99C3-E223FF3C5EEE}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AsyncGenerator.CommandLine", "AsyncGenerator.CommandLine/AsyncGenerator.CommandLine.csproj", "{BF73EAAC-697E-456C-A323-3DF13A00EC64}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AsyncGenerator.CommandLine", "AsyncGenerator.CommandLine\AsyncGenerator.CommandLine.csproj", "{BF73EAAC-697E-456C-A323-3DF13A00EC64}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AsyncGenerator.Tool", "AsyncGenerator.Tool\AsyncGenerator.Tool.csproj", "{DB1892E6-5980-4005-9CEB-B4B0E46FAA97}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -45,8 +47,15 @@ Global
 		{BF73EAAC-697E-456C-A323-3DF13A00EC64}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{BF73EAAC-697E-456C-A323-3DF13A00EC64}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{BF73EAAC-697E-456C-A323-3DF13A00EC64}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DB1892E6-5980-4005-9CEB-B4B0E46FAA97}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DB1892E6-5980-4005-9CEB-B4B0E46FAA97}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DB1892E6-5980-4005-9CEB-B4B0E46FAA97}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DB1892E6-5980-4005-9CEB-B4B0E46FAA97}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {03161291-4CAD-4F5B-B2C6-081AB05963F0}
 	EndGlobalSection
 EndGlobal

--- a/build.cake
+++ b/build.cake
@@ -23,6 +23,7 @@ var buildDirs = new List<string>()
 {
     Directory("./Source/AsyncGenerator/bin") + Directory(configuration),
     Directory("./Source/AsyncGenerator.CommandLine/bin") + Directory(configuration),
+    Directory("./Source/AsyncGenerator.Tool/bin") + Directory(configuration),
     Directory("./Source/AsyncGenerator.Configuration.Yaml/bin") + Directory(configuration),
     Directory("./Source/AsyncGenerator.Core/bin") + Directory(configuration)
 };
@@ -202,6 +203,13 @@ Task("Pack")
                 .Append("/p:PackageOutputPath=\"" + PACKAGE_DIR + "\"")
         });
     }
+
+    DotNetCorePack("Source/AsyncGenerator.Tool/AsyncGenerator.Tool.csproj", new DotNetCorePackSettings {
+        Configuration = configuration,
+        OutputDirectory = PACKAGE_DIR,
+        IncludeSymbols = false,
+        ArgumentCustomization = arg => arg.Append("/p:PackAsTool=true")
+    });
 });
     
 Task("Publish")

--- a/build.cake
+++ b/build.cake
@@ -46,6 +46,7 @@ $@"<Project>
     <TestTargetFramework>{framework}</TestTargetFramework>
     <AppTargetFrameworks>{framework}</AppTargetFrameworks>
     <LibTargetFrameworks>{framework}</LibTargetFrameworks>
+    <ToolTargetFramework>{framework}</ToolTargetFramework>
   </PropertyGroup>
 </Project>";
     }


### PR DESCRIPTION
And remove publishing `AsyncGenerator.CommandLine` as a dotnet tool in order to be able to reference it as a package reference.