### PR TITLE
Fix transforming NUnit Assert.That when using generic argument

### DIFF
--- a/Source/AsyncGenerator.Core/Extensions/Internal/SyntaxNodeExtensions.cs
+++ b/Source/AsyncGenerator.Core/Extensions/Internal/SyntaxNodeExtensions.cs
@@ -1,0 +1,30 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+using static AsyncGenerator.Core.Extensions.Internal.SyntaxNodeHelper;
+
+namespace AsyncGenerator.Core.Extensions.Internal
+{
+	internal static partial class SyntaxNodeExtensions
+	{
+		internal static TypeSyntax WrapIntoTask(this TypeSyntax typeNode, bool withFullName = false)
+		{
+			if (typeNode.ChildTokens().Any(o => o.IsKind(SyntaxKind.VoidKeyword)))
+			{
+				var taskNode = IdentifierName(nameof(Task)).WithTriviaFrom(typeNode);
+				return withFullName
+					? QualifiedName(ConstructNameSyntax("System.Threading.Tasks"), taskNode)
+					: (TypeSyntax)taskNode;
+			}
+			var genericTaskNode = GenericName(nameof(Task))
+				.WithTriviaFrom(typeNode)
+				.AddTypeArgumentListArguments(typeNode.WithoutTrivia());
+			return withFullName
+				? QualifiedName(ConstructNameSyntax("System.Threading.Tasks"), genericTaskNode)
+				: (TypeSyntax)genericTaskNode;
+		}
+	}
+}

--- a/Source/AsyncGenerator.Core/Extensions/Internal/SyntaxNodeHelper.cs
+++ b/Source/AsyncGenerator.Core/Extensions/Internal/SyntaxNodeHelper.cs
@@ -1,0 +1,68 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace AsyncGenerator.Core.Extensions.Internal
+{
+	internal static class SyntaxNodeHelper
+	{
+		internal static NameSyntax ConstructNameSyntax(string name, SyntaxTrivia? trailingTrivia = null, bool insideCref = false, bool onlyName = false)
+		{
+			var names = name.Split('.').ToList();
+			if (onlyName)
+			{
+				return GetSimpleName(names.Last(), insideCref: insideCref);
+			}
+
+			var trailingTriviaList = names.Count <= 2 && trailingTrivia.HasValue
+				? TriviaList(trailingTrivia.Value)
+				: TriviaList();
+			if (names.Count < 2)
+			{
+				return GetSimpleName(name, TriviaList(), trailingTriviaList, insideCref);
+			}
+			var result = QualifiedName(IdentifierName(names[0]), GetSimpleName(names[1], TriviaList(), trailingTriviaList, insideCref));
+			for (var i = 2; i < names.Count; i++)
+			{
+				trailingTriviaList = i + 1 == names.Count && trailingTrivia.HasValue
+					? TriviaList(trailingTrivia.Value)
+					: TriviaList();
+				result = QualifiedName(result, GetSimpleName(names[i], TriviaList(), trailingTriviaList, insideCref));
+			}
+			return result;
+		}
+
+		// TODO: Use symbol for type arguments
+		private static SimpleNameSyntax GetSimpleName(string name, SyntaxTriviaList? leadingTrivia = null, SyntaxTriviaList? trailingTrivia = null, bool insideCref = false)
+		{
+			if (!name.Contains("<"))
+			{
+				return IdentifierName(Identifier(leadingTrivia ?? TriviaList(), name, trailingTrivia ?? TriviaList()));
+			}
+			var start = name.IndexOf('<');
+			var type = name.Substring(0, start);
+			var typeArguments = name.Substring(start + 1, name.Length - start - 2).Split(',').Select(o => o.Trim(' '));
+			var argList = new List<TypeSyntax>();
+			foreach (var argument in typeArguments)
+			{
+				argList.Add(GetSimpleName(argument));
+			}
+			var list = argList.Count == 1
+				? SingletonSeparatedList(argList[0])
+				: SeparatedList(argList);
+			var typeArgList = TypeArgumentList(list);
+			if (insideCref)
+			{
+				typeArgList = typeArgList
+					.WithLessThanToken(Token(TriviaList(), SyntaxKind.LessThanToken, "{", "{", TriviaList()))
+					.WithGreaterThanToken(Token(TriviaList(), SyntaxKind.GreaterThanToken, "}", "}", TriviaList()));
+			}
+			return GenericName(type)
+				.WithTypeArgumentList(typeArgList);
+		}
+	}
+}

--- a/Source/AsyncGenerator.Tests/NUnit/Input/AssertThat.cs
+++ b/Source/AsyncGenerator.Tests/NUnit/Input/AssertThat.cs
@@ -38,6 +38,7 @@ namespace AsyncGenerator.Tests.NUnit.Input
 
 			var result = false;
 			Assert.That(() => result = SimpleFile.Write(""), Throws.Nothing);
+			Assert.That<bool>(() => result = SimpleFile.Write(""), Throws.Nothing);
 			Assert.IsTrue(result);
 
 		}

--- a/Source/AsyncGenerator.Tests/NUnit/Output/AssertThat.txt
+++ b/Source/AsyncGenerator.Tests/NUnit/Output/AssertThat.txt
@@ -48,6 +48,7 @@ namespace AsyncGenerator.Tests.NUnit.Input
 
 			var result = false;
 			Assert.That(async () => result = await (SimpleFile.WriteAsync("")), Throws.Nothing);
+			Assert.That<Task<bool>>(async () => result = await (SimpleFile.WriteAsync("")), Throws.Nothing);
 			Assert.IsTrue(result);
 
 		}

--- a/Source/AsyncGenerator/AsyncGenerator.csproj
+++ b/Source/AsyncGenerator/AsyncGenerator.csproj
@@ -19,6 +19,12 @@
     <Compile Include="..\AsyncGenerator.Core\Extensions\Internal\SymbolExtensions.cs" Link="Extensions\SymbolExtensions.cs" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\AsyncGenerator.Core\Extensions\Internal\SyntaxNodeExtensions.cs" Link="Extensions\SyntaxNodeExtensions.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\AsyncGenerator.Core\Extensions\Internal\SyntaxNodeHelper.cs" Link="Extensions\SyntaxNodeHelper.cs" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(MicrosoftCodeAnalysisVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="$(MicrosoftCodeAnalysisVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="$(MicrosoftCodeAnalysisVersion)" />

--- a/Source/AsyncGenerator/Extensions/Internal/SymbolExtensions.cs
+++ b/Source/AsyncGenerator/Extensions/Internal/SymbolExtensions.cs
@@ -8,6 +8,7 @@ using AsyncGenerator.Core.Extensions.Internal;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using static AsyncGenerator.Core.Extensions.Internal.SyntaxNodeHelper;
 
 namespace AsyncGenerator.Extensions.Internal
 {
@@ -121,7 +122,7 @@ namespace AsyncGenerator.Extensions.Internal
 					? (TypeSyntax)SyntaxFactory.NullableType(predefinedType)
 					: predefinedType;
 			}
-			return SyntaxNodeExtensions.ConstructNameSyntax(symbol.ToString(), insideCref: insideCref, onlyName: onlyName);
+			return ConstructNameSyntax(symbol.ToString(), insideCref: insideCref, onlyName: onlyName);
 		}
 
 		internal static bool IsEventAccessor(this ISymbol symbol)

--- a/Source/AsyncGenerator/Extensions/Internal/SyntaxNodeExtensions.cs
+++ b/Source/AsyncGenerator/Extensions/Internal/SyntaxNodeExtensions.cs
@@ -13,6 +13,8 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Text;
 using SyntaxTrivia = Microsoft.CodeAnalysis.SyntaxTrivia;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+using static AsyncGenerator.Core.Extensions.Internal.SyntaxNodeHelper;
+using AsyncGenerator.Core.Extensions.Internal;
 
 namespace AsyncGenerator.Extensions.Internal
 {
@@ -224,23 +226,6 @@ namespace AsyncGenerator.Extensions.Internal
 			return methodNode.WithReturnType(
 				methodNode.ReturnType.WrapIntoTask(withFullName)
 			);
-		}
-
-		internal static TypeSyntax WrapIntoTask(this TypeSyntax typeNode, bool withFullName = false)
-		{
-			if (typeNode.ChildTokens().Any(o => o.IsKind(SyntaxKind.VoidKeyword)))
-			{
-				var taskNode = IdentifierName(nameof(Task)).WithTriviaFrom(typeNode);
-				return withFullName
-					? QualifiedName(ConstructNameSyntax("System.Threading.Tasks"), taskNode)
-					: (TypeSyntax)taskNode;
-			}
-			var genericTaskNode = GenericName(nameof(Task))
-				.WithTriviaFrom(typeNode)
-				.AddTypeArgumentListArguments(typeNode.WithoutTrivia());
-			return withFullName
-				? QualifiedName(ConstructNameSyntax("System.Threading.Tasks"), genericTaskNode)
-				: (TypeSyntax) genericTaskNode;
 		}
 
 		internal static SyntaxTrivia GetLeadingWhitespace(this SyntaxNode node)
@@ -1227,60 +1212,7 @@ namespace AsyncGenerator.Extensions.Internal
 			return InvocationExpression(identifier, ArgumentList(SeparatedList<ArgumentSyntax>(argumentList)));
 		}
 
-		internal static NameSyntax ConstructNameSyntax(string name, SyntaxTrivia? trailingTrivia = null, bool insideCref = false, bool onlyName = false)
-		{
-			var names = name.Split('.').ToList();
-			if (onlyName)
-			{
-				return GetSimpleName(names.Last(), insideCref: insideCref);
-			}
-
-			var trailingTriviaList = names.Count <= 2 && trailingTrivia.HasValue
-				? TriviaList(trailingTrivia.Value)
-				: TriviaList();
-			if (names.Count < 2)
-			{
-				return GetSimpleName(name, TriviaList(), trailingTriviaList, insideCref);
-			}
-			var result = QualifiedName(IdentifierName(names[0]), GetSimpleName(names[1], TriviaList(), trailingTriviaList, insideCref));
-			for (var i = 2; i < names.Count; i++)
-			{
-				trailingTriviaList = i + 1 == names.Count && trailingTrivia.HasValue
-					? TriviaList(trailingTrivia.Value)
-					: TriviaList();
-				result = QualifiedName(result, GetSimpleName(names[i], TriviaList(), trailingTriviaList, insideCref));
-			}
-			return result;
-		}
-
-		// TODO: Use symbol for type arguments
-		private static SimpleNameSyntax GetSimpleName(string name, SyntaxTriviaList? leadingTrivia = null, SyntaxTriviaList? trailingTrivia = null, bool insideCref = false)
-		{
-			if (!name.Contains("<"))
-			{
-				return IdentifierName(Identifier(leadingTrivia ?? TriviaList(), name, trailingTrivia ?? TriviaList()));
-			}
-			var start = name.IndexOf('<');
-			var type = name.Substring(0, start);
-			var typeArguments = name.Substring(start + 1, name.Length - start - 2).Split(',').Select(o => o.Trim(' '));
-			var argList = new List<TypeSyntax>();
-			foreach (var argument in typeArguments)
-			{
-				argList.Add(GetSimpleName(argument));
-			}
-			var list = argList.Count == 1
-				? SingletonSeparatedList(argList[0])
-				: SeparatedList(argList);
-			var typeArgList = TypeArgumentList(list);
-			if (insideCref)
-			{
-				typeArgList = typeArgList
-					.WithLessThanToken(Token(TriviaList(), SyntaxKind.LessThanToken, "{", "{", TriviaList()))
-					.WithGreaterThanToken(Token(TriviaList(), SyntaxKind.GreaterThanToken, "}", "}", TriviaList()));
-			}
-			return GenericName(type)
-				.WithTypeArgumentList(typeArgList);
-		}
+		
 
 		internal static FileLinePositionSpan GetLineSpan(this SyntaxNode node)
 		{

--- a/Source/AsyncGenerator/Transformation/Internal/AsyncLockMethodTransformer.cs
+++ b/Source/AsyncGenerator/Transformation/Internal/AsyncLockMethodTransformer.cs
@@ -16,7 +16,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
-using SyntaxNodeExtensions = AsyncGenerator.Extensions.Internal.SyntaxNodeExtensions;
+using static AsyncGenerator.Core.Extensions.Internal.SyntaxNodeHelper;
 
 
 namespace AsyncGenerator.Transformation.Internal
@@ -141,7 +141,7 @@ namespace AsyncGenerator.Transformation.Internal
 				list = list.Add(Token(TriviaList(), SyntaxKind.StaticKeyword, TriviaList(Space)));
 			}
 			list = list.Add(Token(TriviaList(), SyntaxKind.ReadOnlyKeyword, TriviaList(Space)));
-			var lockType = SyntaxNodeExtensions.ConstructNameSyntax(_configuration.AsyncLockFullTypeName, Space);
+			var lockType = ConstructNameSyntax(_configuration.AsyncLockFullTypeName, Space);
 			return FieldDeclaration(
 					VariableDeclaration(lockType)
 						.WithVariables(
@@ -151,7 +151,7 @@ namespace AsyncGenerator.Transformation.Internal
 									)
 									.WithInitializer(
 										EqualsValueClause(
-											ObjectCreationExpression(SyntaxNodeExtensions.ConstructNameSyntax(_configuration.AsyncLockFullTypeName))
+											ObjectCreationExpression(ConstructNameSyntax(_configuration.AsyncLockFullTypeName))
 												.WithArgumentList(ArgumentList())
 												.WithNewKeyword(Token(TriviaList(), SyntaxKind.NewKeyword, TriviaList(Space)))
 										)

--- a/Source/AsyncGenerator/Transformation/Internal/OperationCanceledExceptionFunctionRewriter.cs
+++ b/Source/AsyncGenerator/Transformation/Internal/OperationCanceledExceptionFunctionRewriter.cs
@@ -11,7 +11,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
-using SyntaxNodeExtensions = AsyncGenerator.Extensions.Internal.SyntaxNodeExtensions;
+using static AsyncGenerator.Core.Extensions.Internal.SyntaxNodeHelper;
 
 namespace AsyncGenerator.Transformation.Internal
 {
@@ -65,7 +65,7 @@ namespace AsyncGenerator.Transformation.Internal
 				.WithDeclaration(
 					CatchDeclaration(_namespaceMetadata.UsingSystem
 							? IdentifierName(nameof(OperationCanceledException))
-							: SyntaxNodeExtensions.ConstructNameSyntax($"System.{nameof(OperationCanceledException)}"))
+							: ConstructNameSyntax($"System.{nameof(OperationCanceledException)}"))
 						.WithCloseParenToken(Token(TriviaList(), SyntaxKind.CloseParenToken, TriviaList(Space))))
 				.WithBlock(
 					Block(SingletonList<StatementSyntax>(

--- a/Source/AsyncGenerator/Transformation/Internal/ProjectTransformer.Function.cs
+++ b/Source/AsyncGenerator/Transformation/Internal/ProjectTransformer.Function.cs
@@ -7,6 +7,7 @@ using AsyncGenerator.Analyzation;
 using AsyncGenerator.Core;
 using AsyncGenerator.Core.Analyzation;
 using AsyncGenerator.Core.Extensions;
+using AsyncGenerator.Core.Extensions.Internal;
 using AsyncGenerator.Core.Transformation;
 using AsyncGenerator.Extensions;
 using AsyncGenerator.Extensions.Internal;

--- a/Source/AsyncGenerator/Transformation/Internal/ProjectTransformer.Method.cs
+++ b/Source/AsyncGenerator/Transformation/Internal/ProjectTransformer.Method.cs
@@ -9,6 +9,7 @@ using AsyncGenerator.Configuration;
 using AsyncGenerator.Core;
 using AsyncGenerator.Core.Analyzation;
 using AsyncGenerator.Core.Extensions;
+using AsyncGenerator.Core.Extensions.Internal;
 using AsyncGenerator.Core.Transformation;
 using AsyncGenerator.Extensions;
 using AsyncGenerator.Extensions.Internal;

--- a/Source/AsyncGenerator/Transformation/Internal/ReturnTaskFunctionRewriter.cs
+++ b/Source/AsyncGenerator/Transformation/Internal/ReturnTaskFunctionRewriter.cs
@@ -17,6 +17,7 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 using SyntaxNodeExtensions = AsyncGenerator.Extensions.Internal.SyntaxNodeExtensions;
+using static AsyncGenerator.Core.Extensions.Internal.SyntaxNodeHelper;
 
 namespace AsyncGenerator.Transformation.Internal
 {
@@ -284,7 +285,7 @@ namespace AsyncGenerator.Transformation.Internal
 					MemberAccessExpression(
 						SyntaxKind.SimpleMemberAccessExpression,
 						_namespaceMetadata.TaskConflict
-							? SyntaxNodeExtensions.ConstructNameSyntax("System.Threading.Tasks.Task").WithLeadingTrivia(node.GetLeadingTrivia())
+							? ConstructNameSyntax("System.Threading.Tasks.Task").WithLeadingTrivia(node.GetLeadingTrivia())
 							: IdentifierName(Identifier(TriviaList(node.GetLeadingTrivia()), nameof(Task), TriviaList())),
 						GenericName(
 								Identifier("FromException"))
@@ -338,7 +339,7 @@ namespace AsyncGenerator.Transformation.Internal
 				MemberAccessExpression(
 					SyntaxKind.SimpleMemberAccessExpression,
 					_namespaceMetadata.TaskConflict
-						? SyntaxNodeExtensions.ConstructNameSyntax("System.Threading.Tasks.Task")
+						? ConstructNameSyntax("System.Threading.Tasks.Task")
 						: IdentifierName(nameof(Task)),
 					IdentifierName("CompletedTask")),
 				Token(TriviaList(), SyntaxKind.SemicolonToken, TriviaList(_transformResult.EndOfLineTrivia))
@@ -387,7 +388,7 @@ namespace AsyncGenerator.Transformation.Internal
 							CatchDeclaration(
 								_namespaceMetadata.UsingSystem
 									? IdentifierName(Identifier(TriviaList(), "Exception", TriviaList(Space)))
-									: SyntaxNodeExtensions.ConstructNameSyntax("System.Exception", Space)
+									: ConstructNameSyntax("System.Exception", Space)
 								)
 								.WithIdentifier(Identifier("ex"))
 								.WithCloseParenToken(Token(TriviaList(), SyntaxKind.CloseParenToken, eolTrivia))
@@ -414,7 +415,7 @@ namespace AsyncGenerator.Transformation.Internal
 										MemberAccessExpression(
 											SyntaxKind.SimpleMemberAccessExpression,
 											_namespaceMetadata.TaskConflict
-												? SyntaxNodeExtensions.ConstructNameSyntax("System.Threading.Tasks.Task")
+												? ConstructNameSyntax("System.Threading.Tasks.Task")
 												: IdentifierName(nameof(Task)),
 											GenericName(
 													Identifier("FromException"))


### PR DESCRIPTION
Fixes the following code:
```C#
var result = false;
Assert.That<bool>(() => result = SimpleFile.Write(""), Throws.Nothing);
```
to be generated as:
```C#
var result = false;
Assert.That<Task<bool>>(async () => result = await (SimpleFile.WriteAsync("")), Throws.Nothing);
```
where currently the generic argument for `Assert.That` is not wrapped into a `Task<>`.